### PR TITLE
Add club discount eligibility for SK slugs

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,6 +66,11 @@ def zpracuj_soubory(vazby_produktu, vazby_akci, zlm):
         
         # Určení hodnoty pro sloupec D na základě slugu
         slug = str(id_dlazdice).lower()
+
+        # Add this new block for 'SK' condition
+        if slug.startswith("sk"):
+            klubova_akce = 1
+        
         if slug.startswith("te"):
             column_d_value = "leaflet"
         elif slug.startswith("ma"):


### PR DESCRIPTION
This change modifies the `zpracuj_soubory` function to mark a tile as a club discount (klubova_akce = 1) if its slug starts with "SK".

Previously, club discounts were only applied if a related product code (obicis) was associated with an "MK" prefix in the ZLM file. This new condition is checked after the "MK" condition and after the slug is generated. If the slug (e.g., from 'id_dlazdice') starts with "sk" (case-insensitive due to prior lowercasing of the slug), klubova_akce will be set to 1. This ensures that "SK" slugs also qualify for the club discount, independently of or in addition to the "MK" condition.